### PR TITLE
Bug Fix for Common Role j2 template

### DIFF
--- a/roles/common/templates/main.conf.j2
+++ b/roles/common/templates/main.conf.j2
@@ -36,7 +36,7 @@ system {
                 }
             }
         } 
-    }
+    
     syslog {
         user * {
             any emergency;


### PR DESCRIPTION
The Common Template has an extra bracket '{' that produces junos config that cannot be loaded.

Removing the extra '{' then allows the resulting junos config to be loaded.
